### PR TITLE
CSS tag is not necessary in webpack's live reload.

### DIFF
--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -8,9 +8,7 @@
     <meta name="author" content="">
 
     <title>Hello Todomvc!</title>
-    <%= if Mix.env == :dev do %>
-      <link rel="stylesheet" href='http://localhost:4001/css/application.css'>
-    <% else %>
+    <%= if Mix.env != :dev do %>
       <link rel="stylesheet" href="<%= static_path(@conn, "/css/application.css") %>">
     <% end %>
   </head>


### PR DESCRIPTION
Fixes #1
